### PR TITLE
Added upvote mutation that can be used in the frontend

### DIFF
--- a/project/server/src/graphql/mutations/quizMutation.ts
+++ b/project/server/src/graphql/mutations/quizMutation.ts
@@ -39,5 +39,17 @@ export default {
     // Måste verifiera att quizet tillhör användaren och osäker på vad deletequiz returnerar
     const deleted = await deleteQuiz(id);
     return deleted;
+  },
+  upvoteQuiz: async (_parent: unknown, { id }, context: any): Promise<unknown> => {
+    return new Promise( (resolve, reject) => {
+      const upvotedQuiz = Quizzes.findByIdAndUpdate(id, {$inc: {
+        upvotes: 1
+      }}, {new: true}); // Increment upvotes and return the new object 
+      if (!upvotedQuiz) {
+        reject(throwMsg(quizNotFound));
+      } else {
+        resolve(upvotedQuiz);
+      }
+    });
   }
 };

--- a/project/server/src/graphql/schemas/quiz.ts
+++ b/project/server/src/graphql/schemas/quiz.ts
@@ -39,6 +39,7 @@ const typeDefs = gql`
     createQuiz(input: QuizInput): Quiz
     updateQuiz(id: ID!, input: QuizInput): Quiz
     deleteQuiz(id: ID!): Quiz
+    upvoteQuiz(id: ID!): Quiz
   }
 `;
 


### PR DESCRIPTION
This regards backend code. 

Example query to upvote a quiz: 

`mutation UpvotesMutation($upvoteQuizId: ID!) {
  upvoteQuiz(id: $upvoteQuizId) {
    upvotes
    title
    id
    creator
  }
} `

Add more properties if you would like to get them. 